### PR TITLE
mediatek: fix USB3 for the GL.iNet GL-MT3000

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
@@ -226,7 +226,7 @@
 
 &xhci {
 	vbus-supply = <&usb_vbus>;
-
+	mediatek,u3p-dis-msk = <0x0>;
 	status = "okay";
 };
 


### PR DESCRIPTION
In mt7981.dtsi, mediatek,u3p-dis-msk is set to 1 by default, which will disable u3port0. So we should override to 0 to enable it for the GL-MT3000 devices.

Run-tested: GL-iNet GL-MT3000