### PR TITLE
ramips: remove unnecessary if for previous kernel versions

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/ethtool.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/ethtool.c
@@ -199,11 +199,7 @@ static void fe_get_ethtool_stats(struct net_device *dev,
 	do {
 		data_src = &hwstats->tx_bytes;
 		data_dst = data;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 		start = u64_stats_fetch_begin(&hwstats->syncp);
-#else
-		start = u64_stats_fetch_begin_irq(&hwstats->syncp);
-#endif
 
 		for (i = 0; i < ARRAY_SIZE(fe_gdma_str); i++)
 			*data_dst++ = *data_src++;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -487,11 +487,7 @@ static void fe_get_stats64(struct net_device *dev,
 	}
 
 	do {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 		start = u64_stats_fetch_begin(&hwstats->syncp);
-#else
-		start = u64_stats_fetch_begin_irq(&hwstats->syncp);
-#endif
 		storage->rx_packets = hwstats->rx_packets;
 		storage->tx_packets = hwstats->tx_packets;
 		storage->rx_bytes = hwstats->rx_bytes;

--- a/target/linux/ramips/files/drivers/pinctrl/pinctrl-aw9523.c
+++ b/target/linux/ramips/files/drivers/pinctrl/pinctrl-aw9523.c
@@ -810,11 +810,7 @@ static int aw9523_init_gpiochip(struct aw9523 *awi, unsigned int npins)
 	gpiochip->set_multiple = aw9523_gpio_set_multiple;
 	gpiochip->set_config = gpiochip_generic_config;
 	gpiochip->parent = dev;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
 	gpiochip->fwnode = dev->fwnode;
-#else
-	gpiochip->of_node = dev->of_node;
-#endif
 	gpiochip->owner = THIS_MODULE;
 	gpiochip->can_sleep = true;
 


### PR DESCRIPTION
Remove unnecessary if for previous kernel versions. After removing kernel 6.1 the kernel is always >= 6.6 so the conditions are unnecessary.